### PR TITLE
docs: Add instructions for the template flag from git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
-## Hedera DApp CRA Template
+# Hedera DApp CRA Template
+
 Hedera DApp Starter Template using Create React App, Material UI and Typescript with HashPack, Blade, and MetaMask wallet support.
 
 ### The template offers:
+
 * Multi-wallet integration out of the box (HashPack, Blade, & MetaMask)
 * Mirror Node Client
 * State management via React Context
 * Material UI
 
 ### How to use
-1. Clone the repo
-2. Execute the following:
 
-```npx create-react-app <my-app-name> --template file:../path/to/your/template/cra-hedera-dapp-template ```
+Execute the following command, replacing `<my-app-name>` with the directory name you wish to create for the new project.
+
+```shell
+npx create-react-app <my-app-name> --template git+ssh://git@github.com/hedera-dev/cra-hedera-dapp-template.git
+```
+## Contributing
+
+You may wish to `git clone` this repo locally first, and then make changes there.
+
+For testing during local development, execute the following command.
+
+```shell
+npx create-react-app <my-app-name> --template file:../path/to/your/template/cra-hedera-dapp-template
+``


### PR DESCRIPTION
- and keep the existing command for template flag from local file directory, moved under contributing section